### PR TITLE
[bugfix] (triton): add row masking to RMSNorm kernel to prevent CUDA illegal memory access

### DIFF
--- a/svg/kernels/triton/rmsnorm.py
+++ b/svg/kernels/triton/rmsnorm.py
@@ -13,6 +13,7 @@ def _rms_norm_fwd_fused(
     Rstd,
     x_stride,
     y_stride,
+    M: tl.constexpr,  # number of rows in X,
     N: tl.constexpr,  # number of columns in X,
     N2: tl.constexpr,
     eps,  # epsilon to avoid division by zero
@@ -22,12 +23,15 @@ def _rms_norm_fwd_fused(
     pid = tl.program_id(0)
     rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)
     cols = tl.arange(0, N2)
-    mask = cols < N
+
+    row_mask = rows < M
+    col_mask = cols < N
+    mask = row_mask[:, None] & col_mask[None, :]
 
     x_ptr = X + rows[:, None] * x_stride + cols[None, :]
     y_ptr = Y + rows[:, None] * y_stride + cols[None, :]
 
-    x = tl.load(x_ptr, mask=mask[None, :], other=0.0).to(tl.float32)
+    x = tl.load(x_ptr, mask=mask, other=0.0).to(tl.float32)
 
     # Compute variance
     _var = x * x
@@ -35,17 +39,17 @@ def _rms_norm_fwd_fused(
     rstd = 1 / tl.sqrt(var + eps)
 
     # Write mean / rstd
-    tl.store(Rstd + rows, rstd)
+    tl.store(Rstd + rows, rstd, mask=row_mask)
     rstd = tl.reshape(rstd, (BLOCK_M, 1))
 
     # Normalize and apply linear transformation
-    w = tl.load(W + cols)
+    w = tl.load(W + cols, mask=col_mask)
     x_hat = x * rstd
     y = x_hat * w
 
     # Write output
     y = y.to(Y.type.element_ty)
-    tl.store(y_ptr, y, mask=mask[None, :])
+    tl.store(y_ptr, y, mask=mask)
 
 
 def triton_rmsnorm_forward(x, w, eps):
@@ -89,6 +93,7 @@ def triton_rmsnorm_forward(x, w, eps):
         rstd,  #
         x.stride(0),
         y.stride(0),
+        M,
         N,
         N2,
         eps,


### PR DESCRIPTION
## Description
This PR modifies `_rms_norm_fwd_fused` kernel. 

Previously, this kernel only masked the column dimension (N2). This potentially causes CUDA illegal memory access errors when processing the final rows of a tensor, especially when N was not a power of two or during vectorized loads.

In this PR, I add row mask to avoid this issue and modify all related `tl.load` and `tl.store`.

## Motivation
When running `bash scripts/wan/wan_t2v_720p_sap.sh` and replace `Wan-AI/Wan2.1-T2V-14B-Diffusers` with `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, I run into triton cuda illegal memory access error and locate it within `_rms_norm_fwd_fused` kernel.
```bash
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```
The related runtime variables are:
```
M=75600,N=1536,BLOCK_M=1
```
This might be due to that, the last grid launched will try to load memory outside range of `W`, which is not protected by mask. Specifically this line `w = tl.load(W + cols)`
In the meantime, the lack of row mask might also cause issue for `M` not divisible by `BLOCK_M`

## Modifications
As illustrated in files changed

## Verification
I run `python -m svg.kernels.triton.rmsnorm` under repo root folder and ensures correctness as below:
```bash
Max |triton - torch|: 2.861023e-06
Triton RMSNorm : 1.015 ms/iter
PyTorch RMSNorm: 2.271 ms/iter
```